### PR TITLE
Remove m2-pro tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
           # - macos-12-large
-          - [go-spacemesh, m2-pro]
+          - [go-spacemesh]
           - windows-latest
     steps:
       - name: Add OpenCL support - Ubuntu
@@ -175,7 +175,7 @@ jobs:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
           # - macos-12-large
-          - [go-spacemesh, m2-pro]
+          - [go-spacemesh]
           - windows-latest
     steps:
       - name: Add OpenCL support - Ubuntu
@@ -219,7 +219,7 @@ jobs:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
           # - macos-12-large
-          - [go-spacemesh, m2-pro]
+          - [go-spacemesh]
           - windows-latest
     steps:
       # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
@@ -231,7 +231,7 @@ jobs:
           sudo ethtool -K eth0 rx off
 
       - name: disable TCP/UDP offload - MacOS
-        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[go-spacemesh, m2-pro]' }}
+        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[go-spacemesh]' }}
         run: |
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
             outname_sufix: "linux-arm64"
           - os: macos-12-large
             outname_sufix: "mac-amd64"
-          - os: [go-spacemesh, m2-pro]
+          - os: [go-spacemesh]
             outname_sufix: "mac-arm64"
           - os: windows-latest
             outname_sufix: "win-amd64"
@@ -95,7 +95,7 @@ jobs:
           destination: ${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/
 
       - name: Install coreutils
-        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[go-spacemesh, m2-pro]' }}
+        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[go-spacemesh]' }}
         run: brew install coreutils
 
       - name: Calculate the hashsum of the zip file


### PR DESCRIPTION
## Motivation

Allow to run all CI jobs on M1 and M2 MacMini Runners

## Test Plan

Jobs are already running on m2 arm macs. Labels can be add anytime